### PR TITLE
fix exit code 1 after cleaning secrets on node rejoin

### DIFF
--- a/tasks/remaining_nodes.yml
+++ b/tasks/remaining_nodes.yml
@@ -54,7 +54,7 @@
       ansible.builtin.shell: |
         set -o pipefail
         "{{ rke2_data_path }}/bin/kubectl" --kubeconfig /etc/rancher/rke2/rke2.yaml \
-        get secrets -n kube-system -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep -E 'node-password\.rke2$' | sed 's/\.node-password\.rke2//g'
+        get secrets -n kube-system -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep -E 'node-password\.rke2$' | sed 's/\.node-password\.rke2//g' || echo ""
       args:
         executable: /bin/bash
       register: nodes_with_passwords # A node name on each line


### PR DESCRIPTION
# Description
Some restores failed for me because of this steps, it happens randomly. Fix is it return empty string instead fail.
<!---
Please include a summary of the change and which issue is fixed.
--->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)

## How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes.
Create a PR into `main` branch.
--->
